### PR TITLE
Override arguments for installers

### DIFF
--- a/src/Svrooij.WinTuner.CmdLets/Commands/NewWtWingetPackage.cs
+++ b/src/Svrooij.WinTuner.CmdLets/Commands/NewWtWingetPackage.cs
@@ -34,7 +34,7 @@ public class NewWtWingetPackage : DependencyCmdlet<Startup>
     /// The folder to store the package in
     /// </summary>
     [Parameter(
-        Mandatory = false,
+        Mandatory = true,
         Position = 1,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true,
@@ -107,6 +107,17 @@ public class NewWtWingetPackage : DependencyCmdlet<Startup>
         HelpMessage = "The desired locale, if available (eg. 'en-US')")]
     public string? Locale { get; set; }
 
+    /// <summary>
+    /// Override the installer arguments
+    /// </summary>
+    [Parameter(
+        Mandatory = false,
+        Position = 8,
+        ValueFromPipeline = false,
+        ValueFromPipelineByPropertyName = false,
+        HelpMessage = "Override the installer arguments")]
+    public string? InstallerArguments { get; set; }
+
     [ServiceDependency]
     private ILogger<NewWtWingetPackage> logger;
 
@@ -152,6 +163,7 @@ public class NewWtWingetPackage : DependencyCmdlet<Startup>
                     InstallerContext = InstallerContext,
                     PackageScript = PackageScript ?? false,
                     Locale = Locale,
+                    OverrideArguments = InstallerArguments
                 },
                 cancellationToken: cancellationToken);
 

--- a/src/Svrooij.WinTuner.CmdLets/Commands/TestWtIntuneWin.cs
+++ b/src/Svrooij.WinTuner.CmdLets/Commands/TestWtIntuneWin.cs
@@ -1,19 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Graph.Beta;
 using Svrooij.PowerShell.DependencyInjection;
 using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using WingetIntune;
-using WingetIntune.Graph;
 using WingetIntune.Intune;
-using WingetIntune.Models;
 using WingetIntune.Testing;
-using GraphModels = Microsoft.Graph.Beta.Models;
 
 namespace Svrooij.WinTuner.CmdLets.Commands;
 /// <summary>

--- a/src/Svrooij.WinTuner.CmdLets/Commands/TestWtSetupFile.cs
+++ b/src/Svrooij.WinTuner.CmdLets/Commands/TestWtSetupFile.cs
@@ -1,19 +1,11 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Graph.Beta;
 using Svrooij.PowerShell.DependencyInjection;
-using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using WingetIntune;
-using WingetIntune.Graph;
-using WingetIntune.Intune;
-using WingetIntune.Models;
 using WingetIntune.Testing;
-using GraphModels = Microsoft.Graph.Beta.Models;
 
 namespace Svrooij.WinTuner.CmdLets.Commands;
 /// <summary>
@@ -29,16 +21,11 @@ namespace Svrooij.WinTuner.CmdLets.Commands;
 [OutputType(typeof(string))]
 public class TestWtSetupFile : DependencyCmdlet<Startup>
 {
-    /// <summary>
-    /// <para type="description">The absolute path to your setup file</para>
-    /// </summary>
-    [Parameter(
-        Mandatory = true,
-        Position = 0,
-        ValueFromPipeline = false,
-        ValueFromPipelineByPropertyName = true,
-        HelpMessage = "Absolute path to your setup file")]
-    public string? SetupFile { get; set; }
+    [ServiceDependency]
+    private ILogger<TestWtSetupFile>? logger;
+
+    [ServiceDependency]
+    private WindowsSandbox? sandbox;
 
     /// <summary>
     /// <para type="description">Override the installer arguments</para>
@@ -52,29 +39,27 @@ public class TestWtSetupFile : DependencyCmdlet<Startup>
     public string? InstallerArguments { get; set; }
 
     /// <summary>
+    /// <para type="description">The absolute path to your setup file</para>
+    /// </summary>
+    [Parameter(
+        Mandatory = true,
+        Position = 0,
+        ValueFromPipeline = false,
+        ValueFromPipelineByPropertyName = true,
+        HelpMessage = "Absolute path to your setup file")]
+    public string? SetupFile { get; set; }
+    /// <summary>
     /// <para type="description">Sleep for x seconds before closing</para>
     /// </summary>
     [Parameter(
         Mandatory = false,
         HelpMessage = "Sleep for x seconds before auto shutdown")]
     public int? Sleep { get; set; }
-
-    [ServiceDependency]
-    private ILogger<TestWtSetupFile>? logger;
-
-    [ServiceDependency]
-    private WindowsSandbox? sandbox;
-
-    [ServiceDependency]
-    private MetadataManager? metadataManager;
-
     /// <inheritdoc/>
     public override async Task ProcessRecordAsync(CancellationToken cancellationToken)
     {
-
-
         var sandboxFile = await sandbox!.PrepareSandboxForInstaller(SetupFile!, InstallerArguments, Sleep, cancellationToken);
-        logger?.LogDebug("Sandbox file created at {sandboxFile}", sandboxFile);
+        logger?.LogDebug("Sandbox file created at {SandboxFile}", sandboxFile);
         var result = await sandbox.RunSandbox(sandboxFile, true, cancellationToken);
         if (result is null)
         {

--- a/src/Svrooij.WinTuner.CmdLets/Svrooij.WinTuner.CmdLets.dll-Help.xml
+++ b/src/Svrooij.WinTuner.CmdLets/Svrooij.WinTuner.CmdLets.dll-Help.xml
@@ -1844,7 +1844,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
           <maml:name>PackageFolder</maml:name>
           <maml:description>
             <maml:para>The folder to store the package in</maml:para>
@@ -1940,10 +1940,22 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InstallerArguments</maml:name>
+          <maml:description>
+            <maml:para>Override the installer arguments</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
         <maml:name>PackageFolder</maml:name>
         <maml:description>
           <maml:para>The folder to store the package in</maml:para>
@@ -2043,6 +2055,18 @@
         <maml:name>Locale</maml:name>
         <maml:description>
           <maml:para>The desired locale, if available (eg. 'en-US')</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>InstallerArguments</maml:name>
+        <maml:description>
+          <maml:para>Override the installer arguments</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>

--- a/src/Svrooij.WinTuner.CmdLets/docs/New-WtWingetPackage.md
+++ b/src/Svrooij.WinTuner.CmdLets/docs/New-WtWingetPackage.md
@@ -13,9 +13,10 @@ Create intunewin file from Winget installer
 ## SYNTAX
 
 ```
-New-WtWingetPackage [-PackageId] <String> [[-PackageFolder] <String>] [[-Version] <String>]
+New-WtWingetPackage [-PackageId] <String> [-PackageFolder] <String> [[-Version] <String>]
  [[-TempFolder] <String>] [-Architecture <Architecture>] [-InstallerContext <InstallerContext>]
- [-PackageScript <Boolean>] [-Locale <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-PackageScript <Boolean>] [-Locale <String>] [-InstallerArguments <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +41,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
@@ -164,6 +165,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -InstallerArguments
+Override the installer arguments
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/src/WingetIntune/Intune/IntuneManager.cs
+++ b/src/WingetIntune/Intune/IntuneManager.cs
@@ -584,7 +584,7 @@ public partial class IntuneManager
                     if (installerSwitches?.Contains("/quiet") != true)
                     {
                         installerSwitches += " " + DefaultInstallerSwitches[InstallerType.Burn];
-                        installerSwitches = installerSwitches.Trim();
+                        installerSwitches = string.Join(" ", installerSwitches.Split(' ').Distinct()).Trim();
                     }
                     package.InstallCommandLine = $"\"{package.InstallerFilename}\" {installerSwitches}";
                     // Have to check the uninstall command

--- a/src/WingetIntune/Intune/IntuneManager.cs
+++ b/src/WingetIntune/Intune/IntuneManager.cs
@@ -72,7 +72,7 @@ public partial class IntuneManager
         await WriteReadmeAsync(packageFolder, packageInfo, cancellationToken);
         await WritePackageInfo(packageFolder, packageInfo, cancellationToken);
 
-        return new Models.WingetPackage(packageInfo, packageFolder, intunePackage!);
+        return new Models.WingetPackage(packageInfo, packageFolder, intunePackage!) { InstallerArguments = packageInfo.InstallCommandLine?.Substring(packageInfo.InstallerFilename?.Length + 3 ?? 0), InstallerFile = packageInfo.InstallerFilename };
     }
 
     /// <summary>
@@ -183,7 +183,7 @@ public partial class IntuneManager
         await WritePackageInfo(packageFolder, packageInfo, cancellationToken);
         await WriteReadmeAsync(packageFolder, packageInfo, cancellationToken);
 
-        return new WingetPackage(packageInfo, packageFolder, intuneFile);
+        return new WingetPackage(packageInfo, packageFolder, intuneFile) { InstallerFile = packageInfo.InstallerFilename, InstallerArguments = packageInfo.InstallCommandLine?.Substring(packageInfo.InstallerFilename?.Length + 3 ?? 0) };
     }
 
     private static string GetPsCommandContent(string command, string successSearch, string message, string? packageId = null, string? action = null)
@@ -521,7 +521,7 @@ public partial class IntuneManager
         package.InstallerContext = installer.ParseInstallerContext() == InstallerContext.Unknown ? (package.InstallerContext ?? packageOptions.InstallerContext) : installer.ParseInstallerContext();
         package.InstallerType = installer.ParseInstallerType();
         package.Installer = installer;
-        if (!package.InstallerType.IsMsi() || packageOptions.PackageScript == true)
+        if (!package.InstallerType.IsMsi() || packageOptions.PackageScript)
         {
             ComputeInstallerCommands(ref package, packageOptions);
         }
@@ -549,7 +549,7 @@ public partial class IntuneManager
     private static readonly Dictionary<InstallerType, string> DefaultInstallerSwitches = new()
     {
         { InstallerType.Inno, "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-" },
-        { InstallerType.Burn, "/quiet /norestart" },
+        { InstallerType.Burn, "/quiet /norestart /install" },
         { InstallerType.Nullsoft, "/S" },
     };
 
@@ -565,7 +565,7 @@ public partial class IntuneManager
         // And it also helps with installers that otherwise would just not install silently or install at all
         if (packageOptions.PackageScript != true)
         {
-            string? installerSwitches = package.Installer?.InstallerSwitches?.GetPreferred();
+            string? installerSwitches = packageOptions.OverrideArguments ?? package.Installer?.InstallerSwitches?.GetPreferred();
             switch (package.InstallerType)
             {
                 case InstallerType.Inno:
@@ -574,14 +574,19 @@ public partial class IntuneManager
                         installerSwitches += " " + DefaultInstallerSwitches[InstallerType.Inno];
                         installerSwitches = installerSwitches.Trim();
                     }
-                    package.InstallCommandLine = $"\"{package.InstallerFilename}\" {installerSwitches ?? DefaultInstallerSwitches[InstallerType.Inno]}";
+                    package.InstallCommandLine = $"\"{package.InstallerFilename}\" {installerSwitches}";
                     // Don't know the uninstall command
                     // Configure the uninstall command for Inno Setup
                     //package.UninstallCommandLine = $"\"{package.InstallerFilename}\" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /D={{0}}";
                     break;
 
                 case InstallerType.Burn:
-                    package.InstallCommandLine = $"\"{package.InstallerFilename}\" {installerSwitches ?? DefaultInstallerSwitches[InstallerType.Burn]}";
+                    if (installerSwitches?.Contains("/quiet") != true)
+                    {
+                        installerSwitches += " " + DefaultInstallerSwitches[InstallerType.Burn];
+                        installerSwitches = installerSwitches.Trim();
+                    }
+                    package.InstallCommandLine = $"\"{package.InstallerFilename}\" {installerSwitches}";
                     // Have to check the uninstall command
                     package.UninstallCommandLine = $"\"{package.InstallerFilename}\" /quiet /norestart /uninstall /passive"; // /burn.ignoredependencies=\"{package.PackageIdentifier}\"
                     break;

--- a/src/WingetIntune/Models/PackageOptions.cs
+++ b/src/WingetIntune/Models/PackageOptions.cs
@@ -6,5 +6,6 @@ public class PackageOptions
     public Architecture Architecture { get; init; }
     public bool PackageScript { get; init; }
     public string? Locale { get; init; }
+    public string? OverrideArguments { get; init; }
     public static PackageOptions Create() => new PackageOptions { Architecture = Architecture.X64, InstallerContext = InstallerContext.System, PackageScript = false };
 }

--- a/src/WingetIntune/Models/WingetPackage.cs
+++ b/src/WingetIntune/Models/WingetPackage.cs
@@ -34,4 +34,14 @@ public class WingetPackage
     /// The filename of the intunewin file
     /// </summary>
     public string PackageFile { get; set; }
+
+    /// <summary>
+    /// Installer filename
+    /// </summary>
+    public string? InstallerFile { get; set; }
+
+    /// <summary>
+    /// Installer arguments
+    /// </summary>
+    public string? InstallerArguments { get; set; }
 }


### PR DESCRIPTION
We are not able to correctly discover all the arguments needed to install each and every app silently. This is mostly because the silent switches are not mandatory in the winget manifest.

This update allows you to specify the correct arguments, and with the new testing method. It should be super chill to fine tune all your packages.