### PR TITLE
Update MsiDecoder (and OpenMCDF) to correct corner-cases in MSI Parsing

### DIFF
--- a/src/Svrooij.WinTuner.CmdLets/packages.lock.json
+++ b/src/Svrooij.WinTuner.CmdLets/packages.lock.json
@@ -621,8 +621,8 @@
       },
       "OpenMcdf": {
         "type": "Transitive",
-        "resolved": "2.3.0",
-        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
+        "resolved": "2.3.1",
+        "contentHash": "2Otbtp5FsIkdtWn4904oftoyOigllM/Auz2V7qIpxNaK+MC1C2ENjNXL3/ZdKWFLOs24/Bi/lYOE254C7s3Pgw=="
       },
       "Riok.Mapperly": {
         "type": "Transitive",
@@ -1131,7 +1131,7 @@
           "Microsoft.Graph.Core": "[3.2.0, )",
           "Microsoft.Identity.Client.Broker": "[4.66.2, )",
           "Microsoft.Identity.Client.Extensions.Msal": "[4.66.2, )",
-          "OpenMcdf": "[2.3.0, )",
+          "OpenMcdf": "[2.3.1, 2.3.1]",
           "Riok.Mapperly": "[3.6.0, )",
           "SvRooij.ContentPrep": "[0.2.2, )",
           "System.IdentityModel.Tokens.Jwt": "[8.0.2, )",

--- a/src/Svrooij.WinTuner.CmdLets/packages.lock.json
+++ b/src/Svrooij.WinTuner.CmdLets/packages.lock.json
@@ -621,8 +621,8 @@
       },
       "OpenMcdf": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "0XVhI+P6pe80xYntIeF6H4F7AIL4ZolMTI5vkm3QUt9XTnRJht6CNYk1eSfI8YInRble6cw91ypF5llPXzKD/A=="
+        "resolved": "2.3.0",
+        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
       },
       "Riok.Mapperly": {
         "type": "Transitive",
@@ -1131,7 +1131,7 @@
           "Microsoft.Graph.Core": "[3.2.0, )",
           "Microsoft.Identity.Client.Broker": "[4.66.2, )",
           "Microsoft.Identity.Client.Extensions.Msal": "[4.66.2, )",
-          "OpenMcdf": "[2.4.1, )",
+          "OpenMcdf": "[2.3.0, )",
           "Riok.Mapperly": "[3.6.0, )",
           "SvRooij.ContentPrep": "[0.2.2, )",
           "System.IdentityModel.Tokens.Jwt": "[8.0.2, )",

--- a/src/WingetIntune.Cli/packages.lock.json
+++ b/src/WingetIntune.Cli/packages.lock.json
@@ -615,8 +615,8 @@
       },
       "OpenMcdf": {
         "type": "Transitive",
-        "resolved": "2.3.0",
-        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
+        "resolved": "2.3.1",
+        "contentHash": "2Otbtp5FsIkdtWn4904oftoyOigllM/Auz2V7qIpxNaK+MC1C2ENjNXL3/ZdKWFLOs24/Bi/lYOE254C7s3Pgw=="
       },
       "Riok.Mapperly": {
         "type": "Transitive",
@@ -784,7 +784,7 @@
           "Microsoft.Graph.Core": "[3.2.0, )",
           "Microsoft.Identity.Client.Broker": "[4.66.2, )",
           "Microsoft.Identity.Client.Extensions.Msal": "[4.66.2, )",
-          "OpenMcdf": "[2.3.0, )",
+          "OpenMcdf": "[2.3.1, 2.3.1]",
           "Riok.Mapperly": "[3.6.0, )",
           "SvRooij.ContentPrep": "[0.2.2, )",
           "System.IdentityModel.Tokens.Jwt": "[8.0.2, )",

--- a/src/WingetIntune.Cli/packages.lock.json
+++ b/src/WingetIntune.Cli/packages.lock.json
@@ -615,8 +615,8 @@
       },
       "OpenMcdf": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "0XVhI+P6pe80xYntIeF6H4F7AIL4ZolMTI5vkm3QUt9XTnRJht6CNYk1eSfI8YInRble6cw91ypF5llPXzKD/A=="
+        "resolved": "2.3.0",
+        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
       },
       "Riok.Mapperly": {
         "type": "Transitive",
@@ -784,7 +784,7 @@
           "Microsoft.Graph.Core": "[3.2.0, )",
           "Microsoft.Identity.Client.Broker": "[4.66.2, )",
           "Microsoft.Identity.Client.Extensions.Msal": "[4.66.2, )",
-          "OpenMcdf": "[2.4.1, )",
+          "OpenMcdf": "[2.3.0, )",
           "Riok.Mapperly": "[3.6.0, )",
           "SvRooij.ContentPrep": "[0.2.2, )",
           "System.IdentityModel.Tokens.Jwt": "[8.0.2, )",

--- a/src/WingetIntune/Msi/MsiDecoder.cs
+++ b/src/WingetIntune/Msi/MsiDecoder.cs
@@ -26,11 +26,11 @@ public class MsiDecoder
     {
         try
         {
-        using (var cf = new CompoundFile(filePath))
-        {
-            load(cf);
+            using (var cf = new CompoundFile(filePath))
+            {
+                load(cf);
+            }
         }
-    }
         catch (CFFileFormatException e)
         {
             throw new InvalidDataException($"MSI Parsing error: Attempted to parse the MSI file at {filePath}, but the file was corrupt.", e);
@@ -41,11 +41,11 @@ public class MsiDecoder
     {
         try
         {
-        using (var cf = new CompoundFile(msiStream))
-        {
-            load(cf);
+            using (var cf = new CompoundFile(msiStream))
+            {
+                load(cf);
+            }
         }
-    }
         catch (CFFileFormatException e)
         {
             throw new InvalidDataException($"MSI Parsing error: Attempted to parse an MSI Stream, but the data was corrupt.", e);
@@ -85,12 +85,12 @@ public class MsiDecoder
     {
         try
         {
-        intToString = LoadStringPool(cf);
+            intToString = LoadStringPool(cf);
 
-        tables = LoadTablesTable(cf);
-        columns = LoadColumns(cf);
-        allTables = LoadAllTables(cf);
-    }
+            tables = LoadTablesTable(cf);
+            columns = LoadColumns(cf);
+            allTables = LoadAllTables(cf);
+        }
         catch (CFItemNotFound e)
         {
             throw new InvalidDataException("MSI Parsing error: A stream was being looked for in the MSI file, but was not found. Either the MSI file is corrupt, or the library used to read the MSI file is broken.", e);
@@ -455,21 +455,13 @@ public class MsiDecoder
     // Read a string, and return both the string, as well as the offset
     private (string, int) ReadString(byte[] data, int index)
     {
-        uint stringRef = stringSize switch
-        switch (stringSize)
+        var stringRef = stringSize switch
         {
             2 => BitConverter.ToUInt16(data, index),
             3 => BitConverter.ToUInt16(data, index) + (uint)(data[index + 2] << 16),
             4 => BitConverter.ToUInt32(data, index),
             _ => throw new InvalidDataException($"MSI Parsing error: attempted to parse a string index of size {stringSize}, but only 2, 3 and 4 are supported.")
         };
-                break;
-            case 4:
-                stringRef = BitConverter.ToUInt32(data, index);
-                break;
-            default:
-                break;
-        }
 
         return (intToString[stringRef], stringSize);
     }
@@ -478,10 +470,6 @@ public class MsiDecoder
     private (int, int) ReadNumber(byte[] data, int index, int bytes)
     {
         bytes = bytes switch
-        {
-            bytes = 2;
-        }
-        else if (bytes == 3)
         {
             1 => 2,
             2 => 2,

--- a/src/WingetIntune/Msi/MsiDecoder.cs
+++ b/src/WingetIntune/Msi/MsiDecoder.cs
@@ -417,6 +417,17 @@ public class MsiDecoder
     // Read an int, and return both the int and the offset
     private (int, int) ReadNumber(byte[] data, int index, int bytes)
     {
+        if (bytes == 1)
+        {
+            bytes = 2;
+        } else if (bytes == 3)
+        {
+            bytes = 4;
+        } else if (bytes > 4)
+        {
+            throw new InvalidDataException($"Attempted to parse an i{bytes}, but only i1,i2,i3 and i4 are supported.");
+        }
+
         int ret = 0, i;
 
         for (i = 0; i < bytes; i++)

--- a/src/WingetIntune/Msi/MsiDecoder.cs
+++ b/src/WingetIntune/Msi/MsiDecoder.cs
@@ -214,6 +214,7 @@ public class MsiDecoder
             if (entryLength == 0 && entryRef == 0)
             {
                 // Empty entry, skip.
+                strings.Add(stringId, "");
                 stringId++;
                 continue;
             }

--- a/src/WingetIntune/Msi/MsiDecoder.cs
+++ b/src/WingetIntune/Msi/MsiDecoder.cs
@@ -10,7 +10,6 @@ public class MsiDecoder
 {
     private int stringSize = 2;
     private Dictionary<uint, string> intToString;
-    private Dictionary<string, uint> stringToInt;
     private string[] tables;
     private List<Dictionary<string, object>> columns;
     private Dictionary<string, List<Dictionary<string, object>>> allTables;
@@ -71,7 +70,6 @@ public class MsiDecoder
     private void load(CompoundFile cf)
     {
         intToString = LoadStringPool(cf);
-        stringToInt = intToString.ToDictionary(x => x.Value, x => x.Key);
 
         tables = LoadTablesTable(cf);
         columns = LoadColumns(cf);

--- a/src/WingetIntune/Msi/MsiDecoder.cs
+++ b/src/WingetIntune/Msi/MsiDecoder.cs
@@ -420,10 +420,12 @@ public class MsiDecoder
         if (bytes == 1)
         {
             bytes = 2;
-        } else if (bytes == 3)
+        }
+        else if (bytes == 3)
         {
             bytes = 4;
-        } else if (bytes > 4)
+        }
+        else if (bytes > 4)
         {
             throw new InvalidDataException($"Attempted to parse an i{bytes}, but only i1,i2,i3 and i4 are supported.");
         }

--- a/src/WingetIntune/Msi/MsiDecoder.cs
+++ b/src/WingetIntune/Msi/MsiDecoder.cs
@@ -232,7 +232,7 @@ public class MsiDecoder
 
                 if (previousEntryLength == 0 && previousEntryRef != 0)
                 {
-                    entryLength += previousEntryLength << 16;
+                    entryLength = (entryLength) + (entryRef << 16);
                 }
             }
 

--- a/src/WingetIntune/WingetIntune.csproj
+++ b/src/WingetIntune/WingetIntune.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Graph.Core" Version="3.2.0" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.66.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.2" />
-    <PackageReference Include="OpenMcdf" Version="2.3.0" />
+    <PackageReference Include="OpenMcdf" Version="[2.3.1]" />
     <PackageReference Include="Riok.Mapperly" Version="3.6.0" />
     <PackageReference Include="SvRooij.ContentPrep" Version="0.2.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />

--- a/src/WingetIntune/WingetIntune.csproj
+++ b/src/WingetIntune/WingetIntune.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Graph.Core" Version="3.2.0" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.66.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.2" />
-    <PackageReference Include="OpenMcdf" Version="2.4.1" />
+    <PackageReference Include="OpenMcdf" Version="2.3.0" />
     <PackageReference Include="Riok.Mapperly" Version="3.6.0" />
     <PackageReference Include="SvRooij.ContentPrep" Version="0.2.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />

--- a/src/WingetIntune/packages.lock.json
+++ b/src/WingetIntune/packages.lock.json
@@ -111,9 +111,9 @@
       },
       "OpenMcdf": {
         "type": "Direct",
-        "requested": "[2.4.1, )",
-        "resolved": "2.4.1",
-        "contentHash": "0XVhI+P6pe80xYntIeF6H4F7AIL4ZolMTI5vkm3QUt9XTnRJht6CNYk1eSfI8YInRble6cw91ypF5llPXzKD/A=="
+        "requested": "[2.3.0, )",
+        "resolved": "2.3.0",
+        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
       },
       "Riok.Mapperly": {
         "type": "Direct",
@@ -514,9 +514,9 @@
       },
       "OpenMcdf": {
         "type": "Direct",
-        "requested": "[2.4.1, )",
-        "resolved": "2.4.1",
-        "contentHash": "0XVhI+P6pe80xYntIeF6H4F7AIL4ZolMTI5vkm3QUt9XTnRJht6CNYk1eSfI8YInRble6cw91ypF5llPXzKD/A=="
+        "requested": "[2.3.0, )",
+        "resolved": "2.3.0",
+        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
       },
       "Riok.Mapperly": {
         "type": "Direct",

--- a/src/WingetIntune/packages.lock.json
+++ b/src/WingetIntune/packages.lock.json
@@ -111,9 +111,9 @@
       },
       "OpenMcdf": {
         "type": "Direct",
-        "requested": "[2.3.0, )",
-        "resolved": "2.3.0",
-        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
+        "requested": "[2.3.1, 2.3.1]",
+        "resolved": "2.3.1",
+        "contentHash": "2Otbtp5FsIkdtWn4904oftoyOigllM/Auz2V7qIpxNaK+MC1C2ENjNXL3/ZdKWFLOs24/Bi/lYOE254C7s3Pgw=="
       },
       "Riok.Mapperly": {
         "type": "Direct",
@@ -514,9 +514,9 @@
       },
       "OpenMcdf": {
         "type": "Direct",
-        "requested": "[2.3.0, )",
-        "resolved": "2.3.0",
-        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
+        "requested": "[2.3.1, 2.3.1]",
+        "resolved": "2.3.1",
+        "contentHash": "2Otbtp5FsIkdtWn4904oftoyOigllM/Auz2V7qIpxNaK+MC1C2ENjNXL3/ZdKWFLOs24/Bi/lYOE254C7s3Pgw=="
       },
       "Riok.Mapperly": {
         "type": "Direct",

--- a/tests/WingetIntune.Tests/packages.lock.json
+++ b/tests/WingetIntune.Tests/packages.lock.json
@@ -405,8 +405,8 @@
       },
       "OpenMcdf": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "0XVhI+P6pe80xYntIeF6H4F7AIL4ZolMTI5vkm3QUt9XTnRJht6CNYk1eSfI8YInRble6cw91ypF5llPXzKD/A=="
+        "resolved": "2.3.0",
+        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
       },
       "Riok.Mapperly": {
         "type": "Transitive",
@@ -568,7 +568,7 @@
           "Microsoft.Graph.Core": "[3.2.0, )",
           "Microsoft.Identity.Client.Broker": "[4.66.2, )",
           "Microsoft.Identity.Client.Extensions.Msal": "[4.66.2, )",
-          "OpenMcdf": "[2.4.1, )",
+          "OpenMcdf": "[2.3.0, )",
           "Riok.Mapperly": "[3.6.0, )",
           "SvRooij.ContentPrep": "[0.2.2, )",
           "System.IdentityModel.Tokens.Jwt": "[8.0.2, )",

--- a/tests/WingetIntune.Tests/packages.lock.json
+++ b/tests/WingetIntune.Tests/packages.lock.json
@@ -405,8 +405,8 @@
       },
       "OpenMcdf": {
         "type": "Transitive",
-        "resolved": "2.3.0",
-        "contentHash": "4KVqjDt8av6LiscYlIOKdWQe9ILoMIFs1YI/Le11wqR7SA32IWumqxagu7OzyRCyDZ2zL01WanHMycCmOnDuVw=="
+        "resolved": "2.3.1",
+        "contentHash": "2Otbtp5FsIkdtWn4904oftoyOigllM/Auz2V7qIpxNaK+MC1C2ENjNXL3/ZdKWFLOs24/Bi/lYOE254C7s3Pgw=="
       },
       "Riok.Mapperly": {
         "type": "Transitive",
@@ -568,7 +568,7 @@
           "Microsoft.Graph.Core": "[3.2.0, )",
           "Microsoft.Identity.Client.Broker": "[4.66.2, )",
           "Microsoft.Identity.Client.Extensions.Msal": "[4.66.2, )",
-          "OpenMcdf": "[2.3.0, )",
+          "OpenMcdf": "[2.3.1, 2.3.1]",
           "Riok.Mapperly": "[3.6.0, )",
           "SvRooij.ContentPrep": "[0.2.2, )",
           "System.IdentityModel.Tokens.Jwt": "[8.0.2, )",


### PR DESCRIPTION
Previously, these would have mis-aligned tables, and prevented or made incorrect the parsing of further values.

Closes #162

Tests pass, but I'm not sure if you would like to add AnyDesk to the tests (it's 10MB).